### PR TITLE
Allow setting variables from cmdline and remove CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS

### DIFF
--- a/cmake/CMakeLists-common.txt
+++ b/cmake/CMakeLists-common.txt
@@ -21,9 +21,9 @@ set( TARGETS_TO_BE_INSTALLED )
 #
 # DEFAULT SETTINGS
 #
-set( CMAKE_INSTALL_MESSAGE         NEVER )
-set( CMAKE_EXPORT_COMPILE_COMMANDS TRUE )
-set( CMAKE_VERBOSE_MAKEFILE        HIGH )
+set( CMAKE_INSTALL_MESSAGE         NEVER CACHE STRING "Show information about copied/unchanged files during install")
+set( CMAKE_EXPORT_COMPILE_COMMANDS TRUE CACHE BOOL "Export JSON file containing compilation commands for tools" )
+set( CMAKE_VERBOSE_MAKEFILE        HIGH CACHE STRING "Verbosity level for makefiles" )
 
 # Always export compile commands in json file
 # (this is quite useful for tools like Sourcetrail)

--- a/cmake/CMakeLists-common.txt
+++ b/cmake/CMakeLists-common.txt
@@ -28,7 +28,6 @@ set( CMAKE_VERBOSE_MAKEFILE        HIGH CACHE STRING "Verbosity level for makefi
 # Always export compile commands in json file
 # (this is quite useful for tools like Sourcetrail)
 set( CMAKE_EXPORT_COMPILE_COMMANDS     ON )
-set( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE )
 
 #
 # C++ compiler


### PR DESCRIPTION
The CMake code for this project could use of some refinements to make it more readable and easier to use as an external library in other CMake projects.

The full commit messages of this first contribution contains more detailed information about the changes suggested here.